### PR TITLE
Allow for dynamic list item height.

### DIFF
--- a/lib/src/tree_view.dart
+++ b/lib/src/tree_view.dart
@@ -87,7 +87,7 @@ class TreeView extends StatefulWidget {
   /// by [ScrollController] to determine the offset of a node and scroll to it).
   ///
   /// Defaults to `40.0`.
-  final double nodeHeight;
+  final double? nodeHeight;
 
   /// The [ScrollController] passed to [ListView.controller].
   final ScrollController? scrollController;


### PR DESCRIPTION
Allow for dynamic tree view item height by making the `nodeHeight` an optional (= allow for `itemExtent` passed to the `ListView` to be `null`).